### PR TITLE
Change Renovate config to look at github tags for Build Harness updates

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
 BUILD_HARNESS_REPO=ghcr.io/defenseunicorns/build-harness/build-harness
-# renovate: datasource=docker depName=ghcr.io/defenseunicorns/build-harness/build-harness versioning=docker
+# renovate: datasource=github-tags depName=defenseunicorns/build-harness
 BUILD_HARNESS_VERSION=1.2.2


### PR DESCRIPTION
For some reason, it takes upwards of 30 minutes after a new image is pushed for Renovate to see it when using docker as the datasource. This changes the datasource to github-tags, which are much faster.